### PR TITLE
Add a command to display live node statistics

### DIFF
--- a/src/ArionumServiceProvider.php
+++ b/src/ArionumServiceProvider.php
@@ -5,6 +5,7 @@ namespace pxgamer\LaravelArionum;
 use Illuminate\Support\ServiceProvider;
 use pxgamer\Arionum\Arionum as ArionumAdapter;
 use pxgamer\LaravelArionum\Exceptions\InvalidNodeUri;
+use pxgamer\LaravelArionum\Console\Commands\ArionumStatisticsCommand;
 
 final class ArionumServiceProvider extends ServiceProvider
 {
@@ -17,6 +18,12 @@ final class ArionumServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->mergeConfigFrom(self::CONFIG_FILE, 'arionum');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ArionumStatisticsCommand::class,
+            ]);
+        }
     }
 
     public function register(): void

--- a/src/Console/Commands/ArionumStatisticsCommand.php
+++ b/src/Console/Commands/ArionumStatisticsCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace pxgamer\LaravelArionum\Console\Commands;
+
+use Illuminate\Console\Command;
+use pxgamer\Arionum\Arionum as ArionumAdapter;
+
+final class ArionumStatisticsCommand extends Command
+{
+    /** {@inheritDoc} */
+    protected $signature = 'arionum:stats';
+    /** {@inheritDoc} */
+    protected $description = 'Display a list of current Arionum statistics';
+
+    public function handle(ArionumAdapter $arionum): void
+    {
+        $statistics = $arionum->getNodeInfo();
+
+        $this->output->table([],[
+            ['Node Hostname', $statistics->hostname],
+            ['Node Version', "{$statistics->version} (DB {$statistics->dbversion})"],
+            ['Network Accounts', $statistics->accounts],
+            ['Network Transactions', $statistics->transactions],
+            ['Network Masternodes', $statistics->masternodes],
+            ['Node Connected Peers', $statistics->peers],
+        ]);
+    }
+}

--- a/src/Console/Commands/ArionumStatisticsCommand.php
+++ b/src/Console/Commands/ArionumStatisticsCommand.php
@@ -7,16 +7,16 @@ use pxgamer\Arionum\Arionum as ArionumAdapter;
 
 final class ArionumStatisticsCommand extends Command
 {
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     protected $signature = 'arionum:stats';
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     protected $description = 'Display a list of current Arionum statistics';
 
     public function handle(ArionumAdapter $arionum): void
     {
         $statistics = $arionum->getNodeInfo();
 
-        $this->output->table([],[
+        $this->output->table([], [
             ['Node Hostname', $statistics->hostname],
             ['Node Version', "{$statistics->version} (DB {$statistics->dbversion})"],
             ['Network Accounts', $statistics->accounts],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a new `arionum:stats` command to Artisan so that details from the node can be checked.

Currently the command includes the following stats:
- Node hostname
- Node version (and database version)
- Number of accounts in the network
- Number of transactions in the network
- Number of masternodes in the network
- Number of peers that the selected node is connected to

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
