### PR TITLE
Update Setup PHP to version 2 and update Prestissimo installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,15 @@ jobs:
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, zip
+        tools: prestissimo
         coverage: pcov
 
     - name: Install Composer dependencies
-      run: |
-        composer global require hirak/prestissimo
-        composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-suggest
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-suggest
 
     - name: PHPUnit Testing
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2019 Owen Voke <owzie123@gmail.com>
+Copyright (c) 2019 Owen Voke <development@voke.dev>
 
 >Permission is hereby granted, free of charge, to any person obtaining a copy
 >of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the Setup PHP GitHub Action to version 2, and moves Prestissimo installation to the Tools config instead of a separate command.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
